### PR TITLE
StackExchange.Redis's broken configuration link is fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ akka.persistence.journal.plugin = "akka.persistence.journal.redis"
 This will run the journal with its default settings. The default settings can be changed with the configuration properties defined in your HOCON config:
 
 ### Configuration
-- `configuration-string` - connection string, as described here: https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Configuration.md#basic-configuration-strings
+- `configuration-string` - connection string, as described here: https://github.com/StackExchange/StackExchange.Redis/blob/master/docs/Configuration.md#basic-configuration-strings
 - `key-prefix` - Redis journals key prefixes. Leave it for default or change it to appropriate value. WARNING: don't change it on production instances.
 
 ## Snapshot config
@@ -38,7 +38,7 @@ akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.redis"
 This will run the snapshot-store with its default settings. The default settings can be changed with the configuration properties defined in your HOCON config:
 
 ### Configuration
-- `configuration-string` - connection string, as described here: https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Configuration.md#basic-configuration-strings
+- `configuration-string` - connection string, as described here: https://github.com/StackExchange/StackExchange.Redis/blob/master/docs/Configuration.md#basic-configuration-strings
 - `key-prefix` - Redis journals key prefixes. Leave it for default or change it to appropriate value. WARNING: don't change it on production instances.
 
 ## Persistence Query


### PR DESCRIPTION
StackExchange.Redis has changed case their's docs folder from Docs to docs on [41f427b](https://github.com/StackExchange/StackExchange.Redis/commit/41f427bb5ed8c23d0992a1411d0c92667b133d8e)

Which effects a link of this repository, the broken link is fixed.
